### PR TITLE
Epd mac

### DIFF
--- a/theano/tensor/blas.py
+++ b/theano/tensor/blas.py
@@ -333,6 +333,11 @@ def default_blas_ldflags():
                 # The env variable is needed to link with mkl
                 new_path = os.path.join(sys.prefix, "lib")
                 v = os.getenv("DYLD_FALLBACK_LIBRARY_PATH", None)
+                if v is not None:
+                    # Explicit version could be replaced by a symbolic
+                    # link called 'Current' created by EPD installer
+                    # This will resolve symbolic links
+                    v = os.path.realpath(v)
 
                 # The python __import__ don't seam to take into account
                 # the new env variable "DYLD_FALLBACK_LIBRARY_PATH"
@@ -341,11 +346,12 @@ def default_blas_ldflags():
                 if v is None or new_path not in v.split(":"):
                     _logger.warning(
                         "The environment variable "
-                        "'DYLD_FALLBACK_LIBRARY_PATH' do not contain "
+                        "'DYLD_FALLBACK_LIBRARY_PATH' does not contain "
                         "the '%s' path in its value. This will make "
                         "Theano use a slow version of BLAS. Update "
                         "'DYLD_FALLBACK_LIBRARY_PATH' to contain the "
-                        "said value, this will disable this warning.")
+                        "said value, this will disable this warning."
+                        % new_path)
 
 
                     use_unix_epd = False


### PR DESCRIPTION
Hi Fred,
This is now working perfectly for me (tested on EPD 7.2 and 7.3 mac).
There was an issue with EPD creating a symbolic link, 'Current' to the explicit version number. I fixed this as well as another minor issue in the string passed to _logger.warning.

I think it should be good to go.

Graham
