### PR TITLE
Register ScalarConstant as Scalar.Constant

### DIFF
--- a/theano/scalar/basic.py
+++ b/theano/scalar/basic.py
@@ -561,6 +561,9 @@ class ScalarVariable(_scalar_py_operators, Variable):
 class ScalarConstant(_scalar_py_operators, Constant):
     pass
 
+# Register ScalarConstant as the type of Constant corresponding to Scalar
+Scalar.Constant = ScalarConstant
+
 
 # Easy constructors
 


### PR DESCRIPTION
This solves a problem uncovered by the previous commit: a variable with
an ndim field could be replaced by a Variable without one.
