### PR TITLE
Integrate the latest version of CNMEM

### DIFF
--- a/theano/sandbox/cuda/cnmem.cpp
+++ b/theano/sandbox/cuda/cnmem.cpp
@@ -186,7 +186,7 @@ static inline std::size_t ceilInt(std::size_t m, std::size_t n) {
 
 class Mutex {
 #ifdef WIN32
-    CRITICAL_SECTION mCriticalSection;
+    mutable CRITICAL_SECTION mCriticalSection;
 #else
     pthread_mutex_t  mMutex;
 #endif
@@ -381,6 +381,8 @@ public:
         mStream = stream; 
 #ifdef CUDA_API_PER_THREAD_DEFAULT_STREAM
         mIsStreamBlocking = false;
+#elif CUDART_VERSION < 5050
+        mIsStreamBlocking = true;
 #else
         unsigned flags = 0;
         CNMEM_CHECK_CUDA(cudaStreamGetFlags(mStream, &flags));

--- a/theano/sandbox/cuda/cnmem.h
+++ b/theano/sandbox/cuda/cnmem.h
@@ -41,7 +41,11 @@
 #define CNMEM_API __declspec(dllimport)
 #endif
 #else
+#ifdef CNMEM_DLLEXPORT
+#define CNMEM_API __attribute__((visibility ("default")))
+#else
 #define CNMEM_API
+#endif
 #endif
 
 #define CNMEM_VERSION 100 // It corresponds to 1.0.0
@@ -249,7 +253,7 @@ cnmemStatus_t CNMEM_API cnmemPrintMemoryState(FILE *file, cudaStream_t stream);
 /**
  * \brief Converts a cnmemStatus_t value to a string.
  */
-const char* cnmemGetErrorString(cnmemStatus_t status);
+const char CNMEM_API * cnmemGetErrorString(cnmemStatus_t status);
 
 /* ********************************************************************************************* */
 


### PR DESCRIPTION
This version comes with two fixes.

1/ Fix a warning due to the visibility attribute needed by Theano.
We changed const char* CNMEM_API to const char CNMEM_API* in the
declaration of cnmemGetErrorString to have the attribute between
char and star. It fixes the warning.

2/ Fix a compilation issue with CUDA 5.0 due to the missing
cudaStreamGetFlags function. It is #defined out when the Runtime
is less than 5.5 (5050 version).